### PR TITLE
ci: bump Swift version to 6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
-    container: swift:6.0
+    container: swift:6.2
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Swift Playground 4.7 uses Swift 6.2.